### PR TITLE
Added response time to proxies and sorted by best when requesting.

### DIFF
--- a/proxytools/models.py
+++ b/proxytools/models.py
@@ -6,7 +6,7 @@ import logging
 import sys
 
 from peewee import (Model, OperationalError, IntegrityError, CompositeKey,
-                    CharField, DateTimeField,
+                    CharField, DateTimeField, DecimalField,
                     IntegerField, SmallIntegerField, BigIntegerField)
 from playhouse.pool import PooledMySQLDatabase
 from playhouse.shortcuts import RetryOperationalError
@@ -43,7 +43,7 @@ class USmallIntegerField(SmallIntegerField):
 
 
 db = MyRetryDB(None)
-db_schema_version = 2
+db_schema_version = 3
 db_step = 250
 
 
@@ -83,6 +83,7 @@ class Proxy(BaseModel):
     password = Utf8mb4CharField(null=True, max_length=32)
     insert_date = DateTimeField(index=True, default=datetime.utcnow)
     scan_date = DateTimeField(index=True, null=True)
+    response_time = DecimalField(null=True, max_digits=10, decimal_places=3)
     fail_count = UIntegerField(index=True, default=0)
     anonymous = USmallIntegerField(index=True, default=ProxyStatus.UNKNOWN)
     niantic = USmallIntegerField(index=True, default=ProxyStatus.UNKNOWN)
@@ -103,6 +104,7 @@ class Proxy(BaseModel):
             'password': proxy['password'],
             'insert_date': proxy.get('insert_date', datetime.utcnow()),
             'scan_date': proxy.get('scan_date', None),
+            'response_time': proxy.get('response_time', None),
             'fail_count': proxy.get('fail_count', 0),
             'anonymous': proxy.get('anonymous', ProxyStatus.UNKNOWN),
             'niantic': proxy.get('niantic', ProxyStatus.UNKNOWN),
@@ -188,6 +190,7 @@ class Proxy(BaseModel):
         result = []
         max_age = datetime.utcnow() - timedelta(seconds=age_secs)
         conditions = ((Proxy.scan_date > max_age) &
+                      (Proxy.response_time is not None) &
                       (Proxy.fail_count == 0) &
                       (Proxy.niantic == ProxyStatus.OK) &
                       (Proxy.ptc_login == ProxyStatus.OK) &
@@ -202,6 +205,7 @@ class Proxy(BaseModel):
             query = (Proxy
                      .select()
                      .where(conditions)
+                     .order_by(Proxy.response_time.asc())
                      .limit(limit)
                      .dicts())
 
@@ -376,6 +380,15 @@ def migrate_database_schema(old_ver):
         Proxy.rehash_all()
         # Recreate hash field unique index.
         migrate(migrator.add_index('proxy', ('hash',), True))
+
+    if old_ver < 3:
+        # Add response time field.
+        migrate(
+            migrator.add_column('proxy', 'response_time',
+                                DecimalField(null=True,
+                                             max_digits=10,
+                                             decimal_places=3))
+        )
 
     # Always log that we're done.
     log.info('Schema upgrade complete.')

--- a/proxytools/proxy_tester.py
+++ b/proxytools/proxy_tester.py
@@ -257,6 +257,7 @@ class ProxyTester():
     def __run_tests(self, proxy):
         result = True
 
+        start = default_timer()
         session = requests.Session()
 
         session.mount('http://', HTTPAdapter(max_retries=self.retries))
@@ -287,6 +288,11 @@ class ProxyTester():
                     log.warning('%s discarded because country %s is ignored.',
                                 proxy['url'], country)
                     break
+
+        response_time = round(default_timer() - start, 3)
+        proxy['response_time'] = response_time
+        log.debug('%s test finished in %.3f seconds.',
+                  proxy['url'], response_time)
 
         self.__update_proxy(proxy, valid=result)
         session.close()
@@ -373,10 +379,7 @@ class ProxyTester():
                 'ptc-login': ProxyStatus.UNKNOWN,
                 'ptc-signup': ProxyStatus.UNKNOWN
             })
-            start = default_timer()
             self.__run_tests(proxy)
-            log.debug('%s test finished in %.3f seconds.',
-                      proxy['url'], default_timer() - start)
 
     def __export_response(self, filename, content):
         filename = '{}/{}'.format(self.download_path, filename)


### PR DESCRIPTION
Figured it'd be handy to include a combined response time of all tests for comparison against each proxy. Then, when requesting valid proxies, sort by lowest response time to get the best one's (in case there are more than the limit requested).

Feel free to reject this and go with something better yourself when you have time, but figured I'd toss it out for consideration. You may also want to change the DB field type since I wasn't entirely sure on the best to use.